### PR TITLE
enh: update examples to use V2 manifest

### DIFF
--- a/2-notify-owner-on-ticket-to-prod-assist/ticket-status-prod-assist/manifest.yaml
+++ b/2-notify-owner-on-ticket-to-prod-assist/ticket-status-prod-assist/manifest.yaml
@@ -1,18 +1,19 @@
-version: "1"
+version: "2"
 name: "Notify On Prod Assist"
 description: "Snap-In to post a comment on a ticket when its stage changes to 'Awaiting Product Assist'"
 
 service_account:
   display_name: "DevRev Bot"
 
-event-sources:
-  - name: devrev-webhook
-    description: Source listening for work_updated events from DevRev.
-    display_name: DevRev Webhook
-    type: devrev-webhook
-    config:
-      event_types:
-        - work_updated
+event_sources:
+  organization:
+    - name: devrev-webhook
+      description: Source listening for work_updated events from DevRev.
+      display_name: DevRev Webhook
+      type: devrev-webhook
+      config:
+        event_types:
+          - work_updated
 
 functions:
   - name: ticket_stage_change

--- a/3-giphy-template/manifest.yaml
+++ b/3-giphy-template/manifest.yaml
@@ -19,7 +19,7 @@ inputs:
   organization:
     - name: giphy_api_key
       description: Giphy API key
-      devrev_field_type: text
+      field_type: text
       default_value:
 
 functions:

--- a/3-giphy-template/manifest.yaml
+++ b/3-giphy-template/manifest.yaml
@@ -1,24 +1,26 @@
-version: "1"
+version: "2"
 name: "Giphy Snapin"
 description: "Snap-In to search and post gif on DevRev Timeline"
 
 service_account:
   display_name: Giphy Bot
 
-event-sources:
-  - name: devrev-webhook
-    description: Event coming from DevRev
-    display_name: Devrev
-    type: devrev-webhook
-    config:
-      event_types:
-        - work_updated
+event_sources:
+  organization:
+    - name: devrev-webhook
+      description: Event coming from DevRev
+      display_name: Devrev
+      type: devrev-webhook
+      config:
+        event_types:
+          - work_updated
 
-globals:
-  - name: giphy_api_key
-    description: Giphy API key
-    devrev_field_type: text
-    default_value:
+inputs:
+  organization:
+    - name: giphy_api_key
+      description: Giphy API key
+      devrev_field_type: text
+      default_value:
 
 functions:
   - name: search_giphy

--- a/4-sample-snap-in/manifest.yaml
+++ b/4-sample-snap-in/manifest.yaml
@@ -1,4 +1,4 @@
-version: '1'
+version: '2'
 
 name: Sample Snap-Ins for DevRev Hackathon
 description: Snap In to add Comments for demonstration purpose.
@@ -6,14 +6,14 @@ description: Snap In to add Comments for demonstration purpose.
 service_account:
   display_name: "DevRev Bot"
 
-event-sources:
-  - name: devrev-webhook
-    description: Event coming from DevRev
-    display_name: DevRev
-    type: devrev-webhook
-    config:
-      event_types:
-        - work_created
+event_sources:
+  organization:
+    - name: devrev-webhook
+      display_name: DevRev
+      type: devrev-webhook
+      config:
+        event_types:
+          - work_created
 
 functions:
   - name: function_1


### PR DESCRIPTION
Updating the doc to use manifest version 2 everywhere.

no-work-item