### PR TITLE
fix: fix validation for V2 manifest

### DIFF
--- a/3-giphy-template/manifest.yaml
+++ b/3-giphy-template/manifest.yaml
@@ -20,7 +20,7 @@ inputs:
     - name: giphy_api_key
       description: Giphy API key
       field_type: text
-      default_value:
+      default_value: dummy_giphy_key
 
 functions:
   - name: search_giphy

--- a/3-giphy-template/manifest.yaml
+++ b/3-giphy-template/manifest.yaml
@@ -20,7 +20,6 @@ inputs:
     - name: giphy_api_key
       description: Giphy API key
       field_type: text
-      default_value: dummy_giphy_key
 
 functions:
   - name: search_giphy


### PR DESCRIPTION
Validation was breaking when there wasn't a default value. Removed the `default_value` key